### PR TITLE
Expose token and attach complete user object as array

### DIFF
--- a/src/KeycloakProvider.php
+++ b/src/KeycloakProvider.php
@@ -346,9 +346,11 @@ class KeycloakProvider extends AbstractProvider
                 $user = $this->getResourceOwner($token);
                 if ($user) {
                     $socialUser = (object)[
+                        'token' => $token,
                         'id' => $user->getId(),
                         'name' => $user->getName(),
-                        'email' => $user->getEmail()
+                        'email' => $user->getEmail(),
+                        'raw' => $user->toArray()
                     ];
                 }
             } catch (\Exception $e) {

--- a/src/KeycloakProvider.php
+++ b/src/KeycloakProvider.php
@@ -346,7 +346,7 @@ class KeycloakProvider extends AbstractProvider
                 $user = $this->getResourceOwner($token);
                 if ($user) {
                     $socialUser = (object)[
-                        'token' => $token,
+                        'token' => $token->getToken(),
                         'id' => $user->getId(),
                         'name' => $user->getName(),
                         'email' => $user->getEmail(),


### PR DESCRIPTION
This patch is to expose the accessToken in the user object but also to attach the complete user record as an array in case there are more then just "email" and "name".