### PR TITLE
Prevent break code without show error message.

### DIFF
--- a/src/KeycloakProvider.php
+++ b/src/KeycloakProvider.php
@@ -236,7 +236,10 @@ class KeycloakProvider extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if (!empty($data['error'])) {
-            $error = $data['error'].': '.$data['error_description'];
+            $error = $data['error'];
+            if (!empty($data['error_description'])) {
+                $error .= ': '. $data['error_description'];
+            }
             throw new IdentityProviderException($error, 0, $data);
         }
     }


### PR DESCRIPTION
The process is broke while executing because var isnt exists.
This verification prevent error: ErrorException Undefined index: error_description